### PR TITLE
babel parser will fall when parse typescript code

### DIFF
--- a/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
+++ b/packages/gatsby-transformer-javascript-frontmatter/src/gatsby-node.js
@@ -37,8 +37,13 @@ async function onCreateNode({
       `functionBind`,
       `functionSent`,
       `dynamicImport`,
-      `flow`,
     ],
+  }
+  
+  if (/^tsx?$/.test(node.extension)) {
+    options.plugins.push(`typescript`);
+  } else {
+    options.plugins.push(`flow`);
   }
 
   let exportsData, frontmatter, error


### PR DESCRIPTION
## Description

Flow plugin is not able to parse typescript code, eg:

```typescript
   const env = process.env.NODE_ENV as string;
```

this will cause error, because there isn't `as` in Flow